### PR TITLE
docs: update README.md to fix incorrect fileGlob

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Then add the plugin to your [semantic-release config](https://semantic-release.g
     [
       "semantic-release-mirror-version",
       {
-        "fileGlob": ["dist/**.md"]
+        "fileGlob": "dist/**.md"
       }
     ],
     "@semantic-release/github",


### PR DESCRIPTION
The `fileGlob` config cannot be an array. When an array is passed to `fileGlob`, it errors with `TypeError: invalid pattern`.

This PR updates the README.md file to pass in a string instead of an array to `fileGlob`.